### PR TITLE
Enable DFU support for PocketBeagle 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
     tags:
       - 'v*-[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -46,7 +48,7 @@ jobs:
 
       - name: Continuous-Release
         uses: softprops/action-gh-release@v2
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+        if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') == false
         with:
           prerelease: true
           name: Continuous Release
@@ -63,6 +65,16 @@ jobs:
         with:
           generate_release_notes: true
           files: |
+            public/tiboot3.bin
+            public/tiboot3-usbdfu.bin
+            public/tispl.bin
+            public/u-boot.img
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v5
+        if: github.event_name == 'pull_request'
+        with:
+          path: |
             public/tiboot3.bin
             public/tiboot3-usbdfu.bin
             public/tispl.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           tag_name: continuous-release
           files: |
             public/tiboot3.bin
+            public/tiboot3-usbdfu.bin
             public/tispl.bin
             public/u-boot.img
 
@@ -63,5 +64,6 @@ jobs:
           generate_release_notes: true
           files: |
             public/tiboot3.bin
+            public/tiboot3-usbdfu.bin
             public/tispl.bin
             public/u-boot.img

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
             public/tiboot3-usbdfu.bin
             public/tispl.bin
             public/u-boot.img
+            public/u-boot-zephyrdfu.img
 
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -69,6 +70,7 @@ jobs:
             public/tiboot3-usbdfu.bin
             public/tispl.bin
             public/u-boot.img
+            public/u-boot-zephyrdfu.img
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
@@ -79,3 +81,4 @@ jobs:
             public/tiboot3-usbdfu.bin
             public/tispl.bin
             public/u-boot.img
+            public/u-boot-zephyrdfu.img

--- a/public/zephyr_dfu.sh
+++ b/public/zephyr_dfu.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+dfu-util -R -a bootloader -D ./tiboot3-usbdfu.bin
+sleep 1
+dfu-util -R -a tispl.bin -D ./tispl.bin
+sleep 1
+dfu-util -R  -a u-boot.img -D ./u-boot-zephyrdfu.img
+sleep 2
+dfu-util -R  -a zephyr.bin -D $1


### PR DESCRIPTION
- Build SPL for DFU. This is required due to the limitation documented here [0].
- Build U-Boot with a bootcommand to autostart ram DFU for zephyr.bin.
- Add a simple script to execute the whole thing using dfu-util.

[0]: https://docs.u-boot.org/en/latest/board/beagle/am62x_beagleplay.html